### PR TITLE
Make sure the plugin runs before others

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -15,7 +15,7 @@ if (!defined('TESSUS_JSON_TRIGGER'))
 }
 
 // Handle failed loader request
-yourls_add_action('loader_failed', 'tessus_json_response');
+yourls_add_action('redirect_keyword_not_found', 'tessus_json_response', 1);
 
 // Check for the trigger
 

--- a/plugin.php
+++ b/plugin.php
@@ -16,6 +16,7 @@ if (!defined('TESSUS_JSON_TRIGGER'))
 
 // Handle failed loader request
 yourls_add_action('redirect_keyword_not_found', 'tessus_json_response', 1);
+yourls_add_action('loader_failed', 'tessus_json_response', 1);
 
 // Check for the trigger
 


### PR DESCRIPTION
Hello there

A few months ago I added a new hook to YOURLS, `redirect_keyword_not_found`, right before `loader_failed`, see [c1517f1f](https://github.com/YOURLS/YOURLS/commit/c1517f1f84baf55e76db0f97814ceb49ffd34bfa#diff-d67cba73799c31c0c862af1d0f6504dff1b64081e7a8cccae4bf9aff63cabdddR68)

As a result, some "keyword not found" plugins, using this newer hook, are run before yours, even if the keyword exists - see https://github.com/YOURLS/YOURLS/issues/2849

This PR is to update your plugin so that it runs before any other "keyword not found" plugin that would use the same hook
